### PR TITLE
feat #16 - [수요조사]조회 로직 및 DTO, Entity 구조 리팩토링

### DIFF
--- a/final/http/survey/survey.http
+++ b/final/http/survey/survey.http
@@ -9,14 +9,15 @@ Authorization: BEARER eyJkYXRlIjoxNzE1MTY1NzY0ODQ5LCJ0eXBlIjoiand0IiwiYWxnIjoiSF
 ### 수요조사 등록
 POST http://localhost:8080/surveys
 Content-Type: application/json
-Authorization: BEARER eyJkYXRlIjoxNzE1MTY1NzY0ODQ5LCJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJwb3NpdGlvbk5hbWUiOiLslYzrsJQiLCJzdWIiOiIyNDA0MDE4MzUiLCJyb2xlIjoiQURNSU4iLCJpbWFnZVVybCI6IjEiLCJuYW1lIjoi6rmA7KeA7ZmYIiwibWVtYmVyU3RhdHVzIjoi7J6s7KeBIiwiZXhwIjoxNzE1MjUyMTY0LCJkZXBhcnROYW1lIjoi7J247IKs7YyAIiwibWVtYmVySWQiOjI0MDQwMTgzNX0.4sqgjgXe2-X75SA3N3ZfHEhTHbBkBv-tk16AmDyrTlI
+Authorization: BEARER eyJkYXRlIjoxNzE2MzU2NjcyMDIxLCJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJwb3NpdGlvbk5hbWUiOiLslYzrsJQiLCJzdWIiOiIyNDA0MDE4MzUiLCJkZXBhcnRObyI6MSwicm9sZSI6IkFETUlOIiwiaW1hZ2VVcmwiOiJodHRwczovL2ltYWdlcy5jdGZhc3NldHMubmV0L2g2Z29vOWd3MWhoNi8yc05adEZBV09kUDFsbVEzM1Z3Uk4zLzI0ZTk1M2I5MjBhOWNkMGZmMmUxZDU4Nzc0MmEyNDcyLzEtaW50cm8tcGhvdG8tZmluYWwuanBnP3c9MTIwMCZoPTk5MiZmbD1wcm9ncmVzc2l2ZSZxPTcwJmZtPWpwZyIsIm5hbWUiOiLquYDsp4DtmZgiLCJtZW1iZXJTdGF0dXMiOiLsnqzsp4EiLCJleHAiOjE3MTY0NDMwNzIsImRlcGFydE5hbWUiOiLsnbjsgqztjIAiLCJtZW1iZXJJZCI6MjQwNDAxODM1fQ.u89UU8nNy6etjzWFj0MjKxE5vqolZdtFn2W9lZy4ECc
 
 {
   "surveyDTO": {
     "surveyTitle": "치과예약이 있어",
     "surveyApplyDate": "2024-05-02",
     "surveyStartDate": [2024, 5, 1],
-    "surveyEndDate": [2024, 5, 2]
+    "surveyEndDate": [2024, 5, 2],
+    "memberId": 241201001
   },
   "answers": ["답변1", "답변2", "답변3"]
 }

--- a/final/src/main/java/com/insider/login/survey/controller/SurveyController.java
+++ b/final/src/main/java/com/insider/login/survey/controller/SurveyController.java
@@ -98,6 +98,8 @@ public class SurveyController extends CommonController {
     @PostMapping("/surveys")
     public ResponseEntity<String> insertSurvey(@RequestBody SurveyInsertRequestDTO request) {
 
+        log.info("check 컨트롤러 진입");
+        log.info("check DTO 확인 {}", request);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
         request.getSurveyDTO().setSurveyApplyDate(nowDate());

--- a/final/src/main/java/com/insider/login/survey/dto/SurveyDTO.java
+++ b/final/src/main/java/com/insider/login/survey/dto/SurveyDTO.java
@@ -14,6 +14,8 @@ public class SurveyDTO {
 
     private LocalDate surveyEndDate;
 
+    private int memberId;
+
     private String name;
 
     private List<SurveyAnswerDTO> answerList;
@@ -30,12 +32,13 @@ public class SurveyDTO {
         this.surveyEndDate = surveyEndDate;
     }
 
-    public SurveyDTO(int surveyNo, String surveyTitle, String surveyApplyDate, LocalDate surveyStartDate, LocalDate surveyEndDate, String name, List<SurveyAnswerDTO> answerList, boolean surveyCompleted) {
+    public SurveyDTO(int surveyNo, String surveyTitle, String surveyApplyDate, LocalDate surveyStartDate, LocalDate surveyEndDate, int memberId, String name, List<SurveyAnswerDTO> answerList, boolean surveyCompleted) {
         this.surveyNo = surveyNo;
         this.surveyTitle = surveyTitle;
         this.surveyApplyDate = surveyApplyDate;
         this.surveyStartDate = surveyStartDate;
         this.surveyEndDate = surveyEndDate;
+        this.memberId = memberId;
         this.name = name;
         this.answerList = answerList;
         this.surveyCompleted = surveyCompleted;
@@ -81,20 +84,20 @@ public class SurveyDTO {
         this.surveyEndDate = surveyEndDate;
     }
 
+    public int getMemberId() {
+        return memberId;
+    }
+
+    public void setMemberId(int memberId) {
+        this.memberId = memberId;
+    }
+
     public String getName() {
         return name;
     }
 
     public void setName(String name) {
         this.name = name;
-    }
-
-    public boolean isSurveyCompleted() {
-        return surveyCompleted;
-    }
-
-    public void setSurveyCompleted(boolean surveyCompleted) {
-        this.surveyCompleted = surveyCompleted;
     }
 
     public List<SurveyAnswerDTO> getAnswerList() {
@@ -105,6 +108,14 @@ public class SurveyDTO {
         this.answerList = answerList;
     }
 
+    public boolean isSurveyCompleted() {
+        return surveyCompleted;
+    }
+
+    public void setSurveyCompleted(boolean surveyCompleted) {
+        this.surveyCompleted = surveyCompleted;
+    }
+
     @Override
     public String toString() {
         return "SurveyDTO{" +
@@ -113,6 +124,7 @@ public class SurveyDTO {
                 ", surveyApplyDate='" + surveyApplyDate + '\'' +
                 ", surveyStartDate=" + surveyStartDate +
                 ", surveyEndDate=" + surveyEndDate +
+                ", memberId=" + memberId +
                 ", name='" + name + '\'' +
                 ", answerList=" + answerList +
                 ", surveyCompleted=" + surveyCompleted +

--- a/final/src/main/java/com/insider/login/survey/entity/Survey.java
+++ b/final/src/main/java/com/insider/login/survey/entity/Survey.java
@@ -13,27 +13,31 @@ public class Survey {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private int surveyNo;
 
-    @Column(name = "SURVEY_TITLE")
+    @Column(name = "SURVEY_TITLE", nullable = false)
     private String surveyTitle;
 
-    @Column(name = "SURVEY_APPLY_DATE")
+    @Column(name = "SURVEY_APPLY_DATE", nullable = false)
     private String surveyApplyDate;
 
-    @Column(name = "SURVEY_START_DATE")
+    @Column(name = "SURVEY_START_DATE", nullable = false)
     private LocalDate surveyStartDate;
 
-    @Column(name = "SURVEY_END_DATE")
+    @Column(name = "SURVEY_END_DATE", nullable = false)
     private LocalDate surveyEndDate;
+
+    @Column(name = "MEMBER_ID", nullable = false)
+    private int memberId;
 
     protected Survey() {
     }
 
-    public Survey(int surveyNo, String surveyTitle, String surveyApplyDate, LocalDate surveyStartDate, LocalDate surveyEndDate) {
+    public Survey(int surveyNo, String surveyTitle, String surveyApplyDate, LocalDate surveyStartDate, LocalDate surveyEndDate, int memberId) {
         this.surveyNo = surveyNo;
         this.surveyTitle = surveyTitle;
         this.surveyApplyDate = surveyApplyDate;
         this.surveyStartDate = surveyStartDate;
         this.surveyEndDate = surveyEndDate;
+        this.memberId = memberId;
     }
 
     public int getSurveyNo() {
@@ -56,6 +60,10 @@ public class Survey {
         return surveyEndDate;
     }
 
+    public int getMemberId() {
+        return memberId;
+    }
+
     @Override
     public String toString() {
         return "Survey{" +
@@ -64,6 +72,7 @@ public class Survey {
                 ", surveyApplyDate='" + surveyApplyDate + '\'' +
                 ", surveyStartDate=" + surveyStartDate +
                 ", surveyEndDate=" + surveyEndDate +
+                ", memberId=" + memberId +
                 '}';
     }
 }

--- a/final/src/main/java/com/insider/login/survey/service/SurveyService.java
+++ b/final/src/main/java/com/insider/login/survey/service/SurveyService.java
@@ -1,5 +1,6 @@
 package com.insider.login.survey.service;
 
+import com.insider.login.leave.repository.LeaveMemberRepository;
 import com.insider.login.survey.dto.SurveyAnswerDTO;
 import com.insider.login.survey.dto.SurveyDTO;
 import com.insider.login.survey.dto.SurveyResponseDTO;
@@ -28,12 +29,14 @@ public class SurveyService {
     private final SurveyRepository surveyRepository;
     private final SurveyAnswerRepository surveyAnswerRepository;
     private final SurveyResponseRepository surveyResponseRepository;
+    private final LeaveMemberRepository memberRepository;
     private final ModelMapper modelMapper;
 
-    public SurveyService(SurveyRepository surveyRepository, SurveyAnswerRepository surveyAnswerRepository, SurveyResponseRepository surveyResponseRepository, ModelMapper modelMapper) {
+    public SurveyService(SurveyRepository surveyRepository, SurveyAnswerRepository surveyAnswerRepository, SurveyResponseRepository surveyResponseRepository, LeaveMemberRepository memberRepository, ModelMapper modelMapper) {
         this.surveyRepository = surveyRepository;
         this.surveyAnswerRepository = surveyAnswerRepository;
         this.surveyResponseRepository = surveyResponseRepository;
+        this.memberRepository = memberRepository;
         this.modelMapper = modelMapper;
     }
 
@@ -63,6 +66,9 @@ public class SurveyService {
                 // 해당 사번이 답변을 등록한 내역이 존재여부 dto에 삽입
                 surveyDTO.setSurveyCompleted(surveyResponseRepository.existsByMemberIdAndSurveyAnswerIn(memberId, answerNoList));
 
+                // 수요조사 작성자의 사번으로 이름 조회 후 dto에 삽입
+                surveyDTO.setName(memberRepository.findNameByMemberId(surveyDTO.getMemberId()));
+
                 DTOList.add(surveyDTO);
             }
 
@@ -85,6 +91,8 @@ public class SurveyService {
     @Transactional
     public String insertSurvey(SurveyDTO surveyDTO, List<String> answers) {
         try {
+            log.info("check surveyDTO {}", surveyDTO);
+            log.info("check answers {}", answers);
             int surveyNo = surveyRepository.save(modelMapper.map(surveyDTO, Survey.class)).getSurveyNo();
 
             int answerSequence = 1;


### PR DESCRIPTION
> 수요조사 조회 시, 해당 수요조사를 등로한 사람의 사번을 꺼내 이름을 조회한 후 등록자의 이름을 포함하도록 하였습니다.
> 수요조사 등록 시 작성자 아이디를 서버가 아닌 클라이언트에서 가져오는 것으로 변경했기 때문에 요청에 memberId를 포함하여 로직을 처리할 수 있도록 DTO와 Entity 구조를 수정하였습니다.