### PR TITLE
feat #46 - [휴가] 휴가 신청 관련 로직 리팩토링

### DIFF
--- a/final/http/Leave/Leave.http
+++ b/final/http/Leave/Leave.http
@@ -9,19 +9,19 @@ Authorization: BEARER eyJkYXRlIjoxNzE1MjQ1NDAzMDgzLCJ0eXBlIjoiand0IiwiYWxnIjoiSF
 ### 휴가 신청
 POST http://localhost:8080/leaveSubmits
 Content-Type: application/json
-Authorization: BEARER eyJkYXRlIjoxNzE1MjQ1NDAzMDgzLCJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJwb3NpdGlvbk5hbWUiOiLslYzrsJQiLCJzdWIiOiIyNDA0MDE4MzUiLCJkZXBhcnRObyI6MSwicm9sZSI6IkFETUlOIiwiaW1hZ2VVcmwiOiJodHRwczovL2ltYWdlcy5jdGZhc3NldHMubmV0L2g2Z29vOWd3MWhoNi8yc05adEZBV09kUDFsbVEzM1Z3Uk4zLzI0ZTk1M2I5MjBhOWNkMGZmMmUxZDU4Nzc0MmEyNDcyLzEtaW50cm8tcGhvdG8tZmluYWwuanBnP3c9MTIwMCZoPTk5MiZmbD1wcm9ncmVzc2l2ZSZxPTcwJmZtPWpwZyIsIm5hbWUiOiLquYDsp4DtmZgiLCJtZW1iZXJTdGF0dXMiOiLsnqzsp4EiLCJleHAiOjE3MTUzMzE4MDMsImRlcGFydE5hbWUiOiLsnbjsgqztjIAiLCJtZW1iZXJJZCI6MjQwNDAxODM1fQ.NhYn5kZeFDQXjyOQAFms0nPGCejTrFXzmhzy9obyY0Y
+Authorization: BEARER eyJkYXRlIjoxNzE2NDQ2MTc0NDc5LCJ0eXBlIjoiand0IiwiYWxnIjoiSFMyNTYifQ.eyJwb3NpdGlvbk5hbWUiOiLslYzrsJQiLCJzdWIiOiIyNDA0MDE4MzUiLCJkZXBhcnRObyI6MSwicm9sZSI6IkFETUlOIiwiaW1hZ2VVcmwiOiJodHRwczovL2ltYWdlcy5jdGZhc3NldHMubmV0L2g2Z29vOWd3MWhoNi8yc05adEZBV09kUDFsbVEzM1Z3Uk4zLzI0ZTk1M2I5MjBhOWNkMGZmMmUxZDU4Nzc0MmEyNDcyLzEtaW50cm8tcGhvdG8tZmluYWwuanBnP3c9MTIwMCZoPTk5MiZmbD1wcm9ncmVzc2l2ZSZxPTcwJmZtPWpwZyIsIm5hbWUiOiLquYDsp4DtmZgiLCJtZW1iZXJTdGF0dXMiOiLsnqzsp4EiLCJleHAiOjE3MTY1MzI1NzQsImRlcGFydE5hbWUiOiLsnbjsgqztjIAiLCJtZW1iZXJJZCI6MjQwNDAxODM1fQ.9bNnA1hzH-GFKboH6Clj5Tjbf0sKkeE-OCwm3XpSd_Q
 
 {
   "leaveSubApplicant": 241201001,
   "leaveSubStartDate": [
     2024,
-    4,
-    1
+    5,
+    31
   ],
   "leaveSubEndDate": [
     2024,
-    4,
-    3
+    6,
+    1
   ],
   "leaveSubType": "연차",
   "leaveSubReason": "휴가 테스트"

--- a/final/src/main/java/com/insider/login/leave/controller/LeaveController.java
+++ b/final/src/main/java/com/insider/login/leave/controller/LeaveController.java
@@ -57,22 +57,18 @@ public class LeaveController extends CommonController {
             pageable = PageRequest.of(pageNumber, 10, Sort.by(Sort.Direction.DESC, properties));
         }
 
-        Page<LeaveSubmitDTO> page = leaveService.selectLeaveSubmitList(memberId, pageable);
-
-        if (page.isEmpty()) {
-            String errorMessage = "신청된 휴가 내역이 없습니다.";
-            ResponseMessage responseMessage = new ResponseMessage(HttpStatus.NOT_FOUND.value(), errorMessage, null);
-            return new ResponseEntity<>(responseMessage, headers, HttpStatus.NOT_FOUND);
-        }
-
-
         Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("page", page);
 
         // 멤버 아이디가 있다면 개인 내역 조회이기 때문에 요청자의 휴가 보유 내역도 같이 전달함
         if (memberId != 0) {
             LeaveInfoDTO leaveInfo = leaveService.getLeaveInfoById(memberId);
             responseMap.put("leaveInfo", leaveInfo);
+        }
+
+        Page<LeaveSubmitDTO> page = leaveService.selectLeaveSubmitList(memberId, pageable);
+
+        if (!page.isEmpty()) {
+            responseMap.put("page", page);
         }
 
         ResponseMessage responseMessage = new ResponseMessage(200, "조회 성공", responseMap);

--- a/final/src/main/java/com/insider/login/leave/controller/LeaveController.java
+++ b/final/src/main/java/com/insider/login/leave/controller/LeaveController.java
@@ -178,31 +178,6 @@ public class LeaveController extends CommonController {
     }
 
     /**
-     * 상세 조회
-     */
-    @GetMapping("/leaveSubmits/{leaveSubNo}")
-    public ResponseEntity<ResponseMessage> selectSubmitByLeaveSubNo(@PathVariable("leaveSubNo") int leaveSubNo) {
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
-
-        LeaveSubmitDTO submit = leaveService.selectSubmitByLeaveSubNo(leaveSubNo);
-
-        if (submit == null) {
-            String errorMessage = "처리 과정에서 문제가 발생했습니다. 다시 시도해주세요";
-            ResponseMessage responseMessage = new ResponseMessage(HttpStatus.NOT_FOUND.value(), errorMessage, null);
-            return new ResponseEntity<>(responseMessage, headers, HttpStatus.NOT_FOUND);
-        }
-
-        Map<String, Object> responseMap = new HashMap<>();
-        responseMap.put("submit", submit);
-
-        ResponseMessage responseMessage = new ResponseMessage(200, "조회 성공", responseMap);
-
-        return new ResponseEntity<>(responseMessage, headers, HttpStatus.OK);
-    }
-
-    /**
      * 휴가 신청 처리
      */
     @PutMapping("/leaveSubmits")

--- a/final/src/main/java/com/insider/login/leave/controller/LeaveController.java
+++ b/final/src/main/java/com/insider/login/leave/controller/LeaveController.java
@@ -185,10 +185,11 @@ public class LeaveController extends CommonController {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
 
+        // 처리자 사번 삽입
         leaveSubmitDTO.setLeaveSubApprover(getTokenInfo().getMemberId());
 
         leaveSubmitDTO.setLeaveSubProcessDate(nowDate());
-        // TODO:: 취소 요청 시 처리 로직 고민
+
         return ResponseEntity.ok().headers(headers).body(leaveService.updateSubmit(leaveSubmitDTO));
     }
 

--- a/final/src/main/java/com/insider/login/leave/repository/LeaveSubmitRepository.java
+++ b/final/src/main/java/com/insider/login/leave/repository/LeaveSubmitRepository.java
@@ -19,4 +19,6 @@ public interface LeaveSubmitRepository extends JpaRepository<LeaveSubmit, Intege
 
     @Query("SELECT l FROM LeaveSubmit l WHERE l.leaveSubApplicant = :applicantId")
     List<LeaveSubmit> findByMemberId(@Param("applicantId") int applicantId);
+
+    LeaveSubmit findById(int leaveSubNo);
 }

--- a/final/src/main/java/com/insider/login/leave/service/LeaveService.java
+++ b/final/src/main/java/com/insider/login/leave/service/LeaveService.java
@@ -88,6 +88,7 @@ public class LeaveService extends LeaveUtil {
                 LeaveSubmit leaveSubmit = leaveSubmitRepository.findById(LeaveSubNo);
                 LeaveSubmitDTO updateDTO = modelMapper.map(leaveSubmit, LeaveSubmitDTO.class);
                 updateDTO.setLeaveSubStatus("취소신청");
+                leaveSubmitRepository.save(modelMapper.map(updateDTO,LeaveSubmit.class));
             }
 
             DTO.setLeaveSubStatus("대기");
@@ -259,8 +260,10 @@ public class LeaveService extends LeaveUtil {
         List<LeaveSubmit> submitList = leaveSubmitRepository.findByMemberId(DTO.getMemberId());
 
         int consumedDays = submitList.stream()
-                // 휴가 유형이 취소가 아닌 것들만 대상으로 함
+                // 제외할 대상 필터링
                 .filter(submit -> !"취소".equals(submit.getLeaveSubType()))
+                .filter(submit -> !"취소".equals(submit.getLeaveSubStatus()))
+                .filter(submit -> !"반려".equals(submit.getLeaveSubStatus()))
                 // 스트림의 각 요소마다 leaveDayCalc 메소드 실행 후 intStream으로 반환
                 .mapToInt(this::leaveDaysCalc)
                 // 스트림의 모든 요소를 더함

--- a/final/src/main/java/com/insider/login/leave/service/LeaveService.java
+++ b/final/src/main/java/com/insider/login/leave/service/LeaveService.java
@@ -150,17 +150,14 @@ public class LeaveService extends LeaveUtil {
 
     public List<LeaveMemberDTO> selectMemberList(String name) {
         try {
-            log.info("확인 서비스 입장 ==============================================");
-            log.info("확인 이름 확인 {}", name);
             List<LeaveMember> leaveMembers = memberRepository.findByName(name);
-            log.info("확인 엔티티반환 확인 {}", leaveMembers );
+
             List<LeaveMemberDTO> DTOList = memberRepository.findByName(name).stream()
                     .map(leaveMember -> {
                         LeaveMemberDTO dto = modelMapper.map(leaveMember, LeaveMemberDTO.class);
                         return dto;
                     }).toList();
 
-            log.info("결과검사 DTOList {}", DTOList);
             // 조회된 부서 번호로 부서 이름 찾기
             for (LeaveMemberDTO DTO : DTOList) {
                 Optional<Department> departmentOptional = departmentRepository.findById(DTO.getDepartNo());

--- a/final/src/main/java/com/insider/login/leave/service/LeaveService.java
+++ b/final/src/main/java/com/insider/login/leave/service/LeaveService.java
@@ -200,8 +200,10 @@ public class LeaveService extends LeaveUtil {
                 tempDTO.setLeaveSubReason(leaveSubmitDTO.getLeaveSubReason());
             }
 
-            if ("승인".equals(leaveSubmitDTO.getLeaveSubStatus())) {
-                LeaveSubmitDTO submitDTO = modelMapper.map(leaveSubmitRepository.findById(leaveSubmitRepository.findById(leaveSubmitDTO.getLeaveSubNo()).getRefLeaveSubNo()), LeaveSubmitDTO.class);
+            if ("승인".equals(leaveSubmitDTO.getLeaveSubStatus()) && tempDTO.getRefLeaveSubNo() != 0) {
+
+                LeaveSubmitDTO submitDTO = modelMapper.map(leaveSubmitRepository.findById(tempDTO.getRefLeaveSubNo()), LeaveSubmitDTO.class);
+
                 submitDTO.setLeaveSubStatus("취소");
                 leaveSubmitRepository.save(modelMapper.map(submitDTO, LeaveSubmit.class));
             }

--- a/final/src/main/java/com/insider/login/leave/service/LeaveService.java
+++ b/final/src/main/java/com/insider/login/leave/service/LeaveService.java
@@ -78,9 +78,16 @@ public class LeaveService extends LeaveUtil {
     @Transactional
     public String insertSubmit(LeaveSubmitDTO DTO) {
         try {
+            // 휴가 신청 번호를 클라이언트에서 받아왔으면 취소 신청 요청임
             if (DTO.getLeaveSubNo() != 0) {
+                int LeaveSubNo = DTO.getLeaveSubNo();
                 DTO.setRefLeaveSubNo(DTO.getLeaveSubNo());
                 DTO.setLeaveSubNo(0);
+
+                // 취소 신청 요청을 보낸 기존 신청의 처리 상태 변경 후 업데이트
+                LeaveSubmit leaveSubmit = leaveSubmitRepository.findById(LeaveSubNo);
+                LeaveSubmitDTO updateDTO = modelMapper.map(leaveSubmit, LeaveSubmitDTO.class);
+                updateDTO.setLeaveSubStatus("취소신청");
             }
 
             DTO.setLeaveSubStatus("대기");

--- a/final/src/main/java/com/insider/login/survey/controller/SurveyController.java
+++ b/final/src/main/java/com/insider/login/survey/controller/SurveyController.java
@@ -98,8 +98,6 @@ public class SurveyController extends CommonController {
     @PostMapping("/surveys")
     public ResponseEntity<String> insertSurvey(@RequestBody SurveyInsertRequestDTO request) {
 
-        log.info("check 컨트롤러 진입");
-        log.info("check DTO 확인 {}", request);
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(new MediaType("application", "json", Charset.forName("UTF-8")));
         request.getSurveyDTO().setSurveyApplyDate(nowDate());

--- a/final/src/main/java/com/insider/login/survey/service/SurveyService.java
+++ b/final/src/main/java/com/insider/login/survey/service/SurveyService.java
@@ -91,8 +91,6 @@ public class SurveyService {
     @Transactional
     public String insertSurvey(SurveyDTO surveyDTO, List<String> answers) {
         try {
-            log.info("check surveyDTO {}", surveyDTO);
-            log.info("check answers {}", answers);
             int surveyNo = surveyRepository.save(modelMapper.map(surveyDTO, Survey.class)).getSurveyNo();
 
             int answerSequence = 1;
@@ -121,10 +119,8 @@ public class SurveyService {
     @Transactional
     public String insertResponse(SurveyResponseDTO responseDTO) {
         try {
-            log.info("check {}", responseDTO.getSurveyAnswer());
             SurveyResponse surveyResponse = modelMapper.map(responseDTO, SurveyResponse.class);
 
-            log.info("check {}", surveyResponse.getSurveyAnswer());
             surveyResponseRepository.save(surveyResponse);
 
             return "수요조사 응답 등록 성공";


### PR DESCRIPTION

> 사용하지 않는 휴가 상세 조회 로직을 삭제하였습니다.
> 소진 일수 계산 과정에 필터를 통해 소진 처리 결과에 따라 소진 일수 계산에 반영할 수 있도록 하였습니다.
> 취소 신청에 대한 승인 처리 시 기존 신청의 처리 상태를 취소로 변경하도록 하였습니다.  
> 취소 신청에 대한 승인 처리 로직 조건에 RefLeaveSubNo의 포함 여부도 추가하였습니다.
